### PR TITLE
Do not substring class names when path does not begin with slash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'groovy'
 apply plugin: 'maven'
 
 sourceCompatibility = 1.8
-version = "0.4.04"
+version = "0.4.05"
 
 dependencies {
     compile gradleApi()

--- a/src/main/groovy/com/ca/apim/gateway/modularassertionbuilder/ModularAssertionBuilder.groovy
+++ b/src/main/groovy/com/ca/apim/gateway/modularassertionbuilder/ModularAssertionBuilder.groovy
@@ -73,10 +73,14 @@ class ModularAssertionBuilder implements Plugin<Project> {
                 )
                 assertionClasses = ''
                 tree.each { File file ->
-                    assertionClasses = assertionClasses + '\n' + file.path.replaceAll('.*/build/classes/java/main/', '')
+                    def path = file.path.replaceAll('.*/build/classes/java/main/', '')
                             .replace(project.sourceSets.main.output.classesDir.toString(),'')
                             .replace("\\", "/")     // for win machines
-                            .substring(1)   // removing leading slash
+                    if (path.startsWith("/")) {
+                        // removing leading slash
+                        path.substring(1)
+                    }
+                    assertionClasses = assertionClasses + '\n' + path
                 }
                 if (assertionClasses.length() > 0) {
                     assertionClasses = assertionClasses.substring(1)
@@ -99,10 +103,14 @@ class ModularAssertionBuilder implements Plugin<Project> {
 
                 assertionClasses = ''
                 tree.each { File file ->
-                    assertionClasses = assertionClasses + '\n' + file.path.replaceAll('.*/build/(classes/java|resources)/main/', '')
+                    def path = file.path.replaceAll('.*/build/(classes/java|resources)/main/', '')
                             .replace(project.sourceSets.main.output.classesDir.toString(),'')
-                            .replace("\\", "/")
-                            .substring(1)   // remove leading slash as with assertion.index
+                            .replace("\\", "/") // for win machines
+                    if (path.startsWith("/")) {
+                        // removing leading slash
+                        path.substring(1)
+                    }
+                    assertionClasses = assertionClasses + '\n' + path
                 }
                 if (assertionClasses.length() > 0) {
                     assertionClasses = assertionClasses.substring(1)


### PR DESCRIPTION
Do not apply substring when path does not begin with slash
Otherwise class names into index files miss the first character.