### PR TITLE
include resource dir in aar index

### DIFF
--- a/src/main/groovy/com/ca/apim/gateway/modularassertionbuilder/ModularAssertionBuilder.groovy
+++ b/src/main/groovy/com/ca/apim/gateway/modularassertionbuilder/ModularAssertionBuilder.groovy
@@ -79,7 +79,7 @@ class ModularAssertionBuilder implements Plugin<Project> {
                 }
 
                 assertionClasses = getAssertionClasses(
-                        project.sourceSets.main.output.classesDirs,
+                        project.sourceSets.main.output.classesDirs + project.sourceSets.main.output.resourcesDir,
                         [
                             exclude: ['**/console/**/*', '**/client/**/*', '**/server/**/*'],
                         ],


### PR DESCRIPTION
include resources in aar index. required for ComparisonAssertion containing a properties file.